### PR TITLE
Make slog-bunyan compatible with Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ path = "lib.rs"
 [dependencies]
 slog = "2"
 slog-json = "2"
-nix = "0.8.0"
 chrono = "0.3.0"
+hostname = "0.1.5"


### PR DESCRIPTION
This commit removes use of `nix::unistd::gethostname` in favour of `hostname::get_hostname()` which is compatible with both Unix and Windows.

In order to fully remove the dependency on `nix`, it also changes `nix::unistd::getpid()` to use `std::process::getpid()`.

On Windows, this takes the crate from not building, to passing tests:

```shell
30 August 2018 23:47 :: JN-P50 :: C:\Users\James\Code\rust\bunyan
> git checkout windows-hostname
Switched to a new branch 'windows-hostname'
Branch 'windows-hostname' set up to track remote branch 'windows-hostname' from 'origin'.
30 August 2018 23:47 :: JN-P50 :: C:\Users\James\Code\rust\bunyan
> cargo test
    Updating registry `https://github.com/rust-lang/crates.io-index`
 Downloading hostname v0.1.5
 Downloading winutil v0.1.1
   Compiling winapi v0.3.5
   Compiling time v0.1.40
   Compiling winutil v0.1.1
   Compiling hostname v0.1.5
   Compiling chrono v0.4.6
   Compiling chrono v0.3.0
   Compiling slog-json v2.2.0
   Compiling slog-bunyan v2.1.1-pre (file:///C:/Users/James/Code/rust/bunyan)
    Finished dev [unoptimized + debuginfo] target(s) in 10.30s
     Running target\debug\deps\slog_bunyan-e7a5bc55ad9231e0.exe

running 1 test
test test::trivial ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests slog-bunyan

running 1 test
test lib.rs -  (line 3) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

On OS X the tests still pass:

```shell
~/Code/rust/bunyan windows-hostname
❯ cargo test
    Finished dev [unoptimized + debuginfo] target(s) in 0.68s
     Running target/debug/deps/slog_bunyan-6c254277162ca234

running 1 test
test test::trivial ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests slog-bunyan

running 1 test
test lib.rs -  (line 3) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

I assume Travis CI will also test this on Linux when I open the pull request, but I have no reason to assume this would not be ok there or on other UNIX-like systems too.