### PR TITLE
Add with_name API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+* Add with_name API for setting bunyan name field
+* Replace level_to_string function with BunyanLevel enum
+* Make slog-bunyan compatible with windows and x86_64-sun-solaris builds
+
 ## 2.1.0 - 2017-04-29
 ### Fixed
 


### PR DESCRIPTION
Add a `with_name` API that allows for the bunyan `name` field to be set with a
user-specified value. The default name of *slog-rs* is still used for the `new` and `default` API calls.