### PR TITLE
Create a v2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.3.0 - 2021-01-10
+### Changed
+
+* Update dependencies
+
 ## 2.2.0 - 2020-01-19
 ## Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-bunyan"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Bunyan formatter for slog-rs"
 keywords = ["log", "logging", "structured", "hierarchical"]


### PR DESCRIPTION
Hello!

It'd be great if you could publish a new release to crates.io with the bumped `chrono` and `hostname` dependencies.  I put together a draft based on the preparation commit for the previous release (2.2.0).

Thanks.