### PR TITLE
Replace chrono with time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "slog-bunyan"
 version = "2.3.0"
+edition = "2018"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Bunyan formatter for slog-rs"
 keywords = ["log", "logging", "structured", "hierarchical"]
@@ -16,5 +17,5 @@ path = "lib.rs"
 [dependencies]
 slog = "2"
 slog-json = "2"
-chrono = "0.4.11"
 hostname = "0.3.0"
+time = { version = "0.3.6", features = ["formatting", "local-offset", "macros"] }


### PR DESCRIPTION
Resolves `cargo audit` flagging this crate's dependencies as having vulnerabilities.