### PR TITLE
Add `nested-values` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ slog = "2"
 slog-json = "2.6"
 hostname = "0.3.0"
 time = { version = "0.3.6", features = ["formatting", "local-offset", "macros"] }
+
+[features]
+nested-values = ["slog-json/nested-values"]


### PR DESCRIPTION
Without this feature, I don't think it's possible to log structured [`SerdeValue`](https://docs.rs/slog/2.7.0/slog/trait.SerdeValue.html)s when using `slog-bunyan`, even though it's supported by `slog-json`.

(And if one tries to use `slog-async` with `nested-values` draining to `slog-bunyan`, it can fail in a very confusing way: https://github.com/slog-rs/async/issues/33)